### PR TITLE
Unlock keychain before Archive

### DIFF
--- a/lib/src/build_ipa.dart
+++ b/lib/src/build_ipa.dart
@@ -94,6 +94,9 @@ File buildIpa({
       workingDirectory: project.root.absolute.path,
     );
 
+    // unlock keychain again, in case the build took too long
+    keyChain.unlock();
+
     // Export ipa
     startFromArgs(
       'xcodebuild',


### PR DESCRIPTION
It might happen that the keychain automatically locks before the script reaches archive. This unlocks it again, just in case